### PR TITLE
Add support for ESP32

### DIFF
--- a/TM1637.cpp
+++ b/TM1637.cpp
@@ -25,6 +25,10 @@
 #define TM1637_CMD_SET_ADDR        0xC0
 #define TM1637_CMD_DISPLAY         0x88
 
+#if defined(ESP32)
+  #define CLOCK_DELAY 1
+#endif
+
 
 /***************
    ---
@@ -192,14 +196,15 @@ uint8_t TM1637::writeByte(uint8_t data)
   // shift out data 8 bits LSB first
   for (uint8_t i = 8; i > 0; i--)
   {
-    digitalWrite(_clock, LOW);
-    digitalWrite(_data, data & 0x01);
-    digitalWrite(_clock, HIGH);
+    writeSync(_clock, LOW);
+    writeSync(_data, data & 0x01);
+    writeSync(_clock, HIGH);
     data >>= 1;
   }
-  digitalWrite(_clock, LOW);
-  digitalWrite(_data, HIGH);
-  digitalWrite(_clock, HIGH);
+
+  writeSync(_clock, LOW);
+  writeSync(_data, HIGH);
+  writeSync(_clock, HIGH);
 
   // get ACKNOWLEDGE
   pinMode(_data, INPUT);
@@ -216,20 +221,27 @@ uint8_t TM1637::writeByte(uint8_t data)
 
 void TM1637::start()
 {
-  digitalWrite(_clock, HIGH);
-  digitalWrite(_data, HIGH);
-  digitalWrite(_data, LOW);
-  digitalWrite(_clock, LOW);
+  writeSync(_clock, HIGH);
+  writeSync(_data, HIGH);
+  writeSync(_data, LOW);
+  writeSync(_clock, LOW);
 }
 
 
 void TM1637::stop()
 {
-  digitalWrite(_clock, LOW);
-  digitalWrite(_data, LOW);
-  digitalWrite(_clock, HIGH);
-  digitalWrite(_data, HIGH);
+  writeSync(_clock, LOW);
+  writeSync(_data, LOW);
+  writeSync(_clock, HIGH);
+  writeSync(_data, HIGH);
 }
 
+void TM1637::writeSync(uint8_t pin, uint8_t val) {
+  digitalWrite(pin, val);
+
+  #ifdef CLOCK_DELAY
+  delayMicroseconds(CLOCK_DELAY);
+  #endif
+}
 
 // -- END OF FILE --

--- a/TM1637.cpp
+++ b/TM1637.cpp
@@ -25,10 +25,6 @@
 #define TM1637_CMD_SET_ADDR        0xC0
 #define TM1637_CMD_DISPLAY         0x88
 
-#if defined(ESP32)
-  #define CLOCK_DELAY 1
-#endif
-
 
 /***************
    ---
@@ -236,12 +232,20 @@ void TM1637::stop()
   writeSync(_data, HIGH);
 }
 
-void TM1637::writeSync(uint8_t pin, uint8_t val) {
+void TM1637::writeSync(uint8_t pin, uint8_t val) 
+{
   digitalWrite(pin, val);
 
-  #ifdef CLOCK_DELAY
-  delayMicroseconds(CLOCK_DELAY);
+  #if defined(ESP32)
+    nanoDelay(2);
   #endif
+
+}
+
+void TM1637::nanoDelay(uint16_t n)    // 240 ==> at 240 MHz
+{
+  volatile uint16_t i;
+  for (i = 0; i < n; ++i);
 }
 
 // -- END OF FILE --

--- a/TM1637.cpp
+++ b/TM1637.cpp
@@ -242,10 +242,10 @@ void TM1637::writeSync(uint8_t pin, uint8_t val)
 
 }
 
-void TM1637::nanoDelay(uint16_t n)    // 240 ==> at 240 MHz
+void TM1637::nanoDelay(uint16_t n)
 {
-  volatile uint16_t i;
-  for (i = 0; i < n; ++i);
+  volatile uint16_t i = n;
+  while (i--);
 }
 
 // -- END OF FILE --

--- a/TM1637.h
+++ b/TM1637.h
@@ -46,6 +46,8 @@ class TM1637
     uint8_t writeByte(uint8_t data);
     void    start();
     void    stop();
+
+    void writeSync(uint8_t pin, uint8_t val);
 };
 
 // -- END OF FILE --

--- a/TM1637.h
+++ b/TM1637.h
@@ -48,6 +48,7 @@ class TM1637
     void    stop();
 
     void writeSync(uint8_t pin, uint8_t val);
+    void nanoDelay(uint16_t n);
 };
 
 // -- END OF FILE --


### PR DESCRIPTION
Hello,

After some debugging this afternoon, I managed to have a working version of the library working on an ESP32.

It was not working because the ESP32 is way too faster that the Arduino UNO for setting a pin value so the clock was not within the specs of the TM1637. The datasheet specify a minimum clock pulse of 400ns but the ESP32 done that in ~50ns.

I add a delay after each write in order to comply with the TM1637 specs. The delay is only added for the ESP32 in order to not slow down the write on the Arduino.

related to https://github.com/RobTillaart/TM1637_RT/issues/3