### PR TITLE
Added support for letters g-z; added keyscan()

### DIFF
--- a/TM1637.h
+++ b/TM1637.h
@@ -35,6 +35,7 @@ class TM1637
     // tune the timing of writing bytes.
     void    setBitDelay(uint8_t bitDelay = 10) { _bitDelay = bitDelay; };
     uint8_t getBitDelay() { return _bitDelay; };
+    uint8_t keyscan(void);
 
   private:
     uint8_t _clock      = -1;


### PR DESCRIPTION
Added the ability to display the letters from g-z, though with the limits of 7 segments, many letters (g,j,k,m,p,q,s,w,x,y,z) cannot be displayed (and display as blank).
Added the ability to display more than one decimal point, by setting bit 0x80 of any character sent to dispalyRaw().  The existing mechanism using pointPos still works.
Also added a routine to poll the keyboard scanner (keyscan()).
