### PR TITLE
Adding displayPChar feature and custom example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ESP32 is supported since 0.2.0 see https://github.com/RobTillaart/TM1637_RT/pull
 - **TM1637()** constructor
 - **void begin(uint8_t clockPin, uint8_t dataPin, uint8_t digits = 6)** set up the connection of the pins to the display.
 As the display is only tested with a 6 digit display, this is used as the default of the digits parameter.
-- **void displayPChar \*buff)** display the buffer, sign bits show as decimal point.
+- **void displayPChar \*buff)** display the buffer. Experimental - Tested on STM32 and Arduino Nano
 - **void displayRaw(uint8_t \* data, uint8_t pointPos)** low level write function.
 - **void displayInt(long value)** idem
 - **void displayFloat(float value)** idem
@@ -42,8 +42,10 @@ As the display is only tested with a 6 digit display, this is used as the defaul
    - '-' (minus) is 0x11
    - a-f are coded as 0x0a-0x0f
    - g-z are coded as 0x12-0x25.  Characters that cannot be represented in 7 segments render as blank.
-
 So "hello " is coded as 0x13, 0x0e, 0x17, 0x17, 0x1a, 0x10
+   
+****void displayPChar \*buff)** Attempts to display every ascii character 0x30 to 0x5F, see example TM1637_custom.ino to insert your own 7 segment patterns.
+Also displayed are ' ', '.' and '-'. Decimal points may also be displayed by setting the character sign bit.
 
 See routine **ascii_to_7segment()** in the example TM1637_keyscan_cooked.ino.  It presents a more convenient interface for displaying text messages on the display.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ESP32 is supported since 0.2.0 see https://github.com/RobTillaart/TM1637_RT/pull
 - **TM1637()** constructor
 - **void begin(uint8_t clockPin, uint8_t dataPin, uint8_t digits = 6)** set up the connection of the pins to the display.
 As the display is only tested with a 6 digit display, this is used as the default of the digits parameter.
-- **void displayPChar \*buff)** display the buffer. Experimental - Tested on STM32 and Arduino Nano
+- **void displayPChar(\*buff)** display the buffer. Experimental - Tested on STM32 and Arduino Nano
 - **void displayRaw(uint8_t \* data, uint8_t pointPos)** low level write function.
 - **void displayInt(long value)** idem
 - **void displayFloat(float value)** idem
@@ -44,8 +44,8 @@ As the display is only tested with a 6 digit display, this is used as the defaul
    - g-z are coded as 0x12-0x25.  Characters that cannot be represented in 7 segments render as blank.
 So "hello " is coded as 0x13, 0x0e, 0x17, 0x17, 0x1a, 0x10
    
-****void displayPChar \*buff)** Attempts to display every ascii character 0x30 to 0x5F, see example TM1637_custom.ino to insert your own 7 segment patterns.
-Also displayed are ' ', '.' and '-'. Decimal points may also be displayed by setting the character sign bit.
+**void displayPChar(\*buff)** Attempts to display every ascii character 0x30 to 0x5F. See example TM1637_custom.ino to insert your own 7 segment patterns.
+Also displayed are  '  ' , '.' and '-' . Decimal points may also be displayed by setting the character sign bit.
 
 See routine **ascii_to_7segment()** in the example TM1637_keyscan_cooked.ino.  It presents a more convenient interface for displaying text messages on the display.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ ESP32 is supported since 0.2.0 see https://github.com/RobTillaart/TM1637_RT/pull
 - **TM1637()** constructor
 - **void begin(uint8_t clockPin, uint8_t dataPin, uint8_t digits = 6)** set up the connection of the pins to the display.
 As the display is only tested with a 6 digit display, this is used as the default of the digits parameter.
+- **void displayPChar \*buff)** display the buffer, sign bits show as decimal point.
 - **void displayRaw(uint8_t \* data, uint8_t pointPos)** low level write function.
 - **void displayInt(long value)** idem
 - **void displayFloat(float value)** idem

--- a/TM1637.cpp
+++ b/TM1637.cpp
@@ -212,9 +212,7 @@ void TM1637::displayPChar( char * data ){
       writeByte(TM1637_CMD_SET_ADDR);
     
       for (int d = _digits-1; d >=0 ; d--)
-//      for (uint8_t d = 0; d < _digits; d++)
       {
-        
         uint8_t i = _digitOrder[d];
         writeByte( asciiTo7Segment(data[i]) );
       }

--- a/TM1637.cpp
+++ b/TM1637.cpp
@@ -201,6 +201,29 @@ void TM1637::setDigitOrder(uint8_t a, uint8_t b,
   _digitOrder[7] = h;
 }
 
+// Set sign bit on any char to display decimal point
+void TM1637::displayPChar( char * data ){
+
+      start();
+      writeByte(TM1637_ADDR_AUTO);
+      stop();
+    
+      start();
+      writeByte(TM1637_CMD_SET_ADDR);
+    
+      for (int d = _digits-1; d >=0 ; d--)
+//      for (uint8_t d = 0; d < _digits; d++)
+      {
+        
+        uint8_t i = _digitOrder[d];
+        writeByte( asciiTo7Segment(data[i]) );
+      }
+      stop();
+    
+      start();
+      writeByte(TM1637_CMD_DISPLAY | _brightness);
+      stop();
+}
 
 void TM1637::displayRaw(uint8_t * data, uint8_t pointPos)
 {
@@ -424,13 +447,41 @@ uint8_t TM1637::keyscan(void)
   return key;
 }
 
-
 // nanoDelay() makes it possible to go into the sub micron delays.
 // It is used to lengthen pulses to be minimal 400 ns but not much longer. See datasheet.
 void TM1637::nanoDelay(uint16_t n)
 {
   volatile uint16_t i = n;
   while (i--);
+}
+
+uint8_t TM1637::asciiTo7Segment ( char c ) { 
+    /*
+        -01-
+    20 |    | 02
+        -40-
+    10 |    | 04
+        -08-    .80
+    */
+    //7+1  Segment patterns for ASCII 0x30-0x5F
+    const uint8_t asciiToSegments[] = { 
+      0x3f,0x06,0x5b,0x4f, 0x66,0x6d,0x7d,0x07, // 0123 4567 
+      0x7f,0x6f,0x09,0x89, 0x58,0x48,0x4c,0xD3, // 89:; <=>?
+      0x5f,0x77,0x7c,0x39, 0x5E,0x79,0x71,0x3d, // @ABC DEFG 
+      0x76,0x06,0x0E,0x75, 0x38,0x37,0x54,0x5c, // HIJK LMNO
+      0x73,0x67,0x50,0x6D, 0x78,0x3E,0x1C,0x9c, // PQRS TUVW
+      0x76,0x6E,0x5B,0x39, 0x52,0x0F,0x23,0x08  // XYZ[ /]^_
+    };
+
+    uint8_t segments = c & 0x80;
+    c &= 0x7f;
+    if ( c >= 0x60 ) c -= 0x20 ; // a-z -> A-Z
+    if ( c == '.' ) segments = 0x80; // decimal point only
+    if ( c == '-' ) segments |= 0x40; // minus sign
+    if ( ( c >= 0x30 ) && ( c <= 0x5F ) ) {
+      segments |= asciiToSegments[ c-0x30 ];
+    }
+    return segments;
 }
 
 

--- a/TM1637.h
+++ b/TM1637.h
@@ -24,6 +24,7 @@ public:
   //  replaces init()
   void begin(uint8_t clockPin, uint8_t dataPin, uint8_t digits = 6);
 
+  void displayPChar( char * data );
   void displayRaw(uint8_t * data, uint8_t pointPos);
   void displayInt(long value);
   void displayFloat(float value);
@@ -64,6 +65,9 @@ private:
 
   void writeSync(uint8_t pin, uint8_t val);
   void nanoDelay(uint16_t n);
+
+  // Override in your own derived class for custom character translation
+  virtual uint8_t asciiTo7Segment ( char c ) ; 
 };
 
 

--- a/examples/TM1637_custom/TM1637_custom.ino
+++ b/examples/TM1637_custom/TM1637_custom.ino
@@ -9,20 +9,27 @@
 // Demonstration of how to display char *buff and override the TM1637 library asciiTo7Segment virtual function
 // to create a custom 7 segment character set. 
 // The letter 'A' becomes swapped with @ in this trivial example
-
-
+// Status: Experimental. Tested on STM32F103C8T6 Blue Pill and Arduino Nano only
 
 #include "TM1637.h"
 
 const int DISPLAY_DIGITS_6 = 6;
- 
+
+// This example shows how to override the TM1637_RT library 7 segment patterns and copy the display output
+// to the serial port overriding and adding to the library methods.
+// myTM1637 inherits from library class TM1637 and overrides the library asciiTo7Segment() method.
+// The derived class displayPChar() method also copies the display output to the serial port.
+
 class myTM1637 : TM1637 {
   public:
   void setBrightness(uint8_t b) { TM1637::setBrightness(b);};
   
   void begin(uint8_t clockPin, uint8_t dataPin, uint8_t digits = 6) {TM1637::begin(clockPin,dataPin,digits);};
   
-  void displayPChar( char * data ) { TM1637::displayPChar( &data[0] );};
+  void displayPChar( char * data ) { 
+    TM1637::displayPChar( &data[0] ); // Call the base class
+    Serial.println(data); // Copy display output to the serial port
+  };
   
   uint8_t asciiTo7Segment ( char c ) { // Override library ascii to 7 segment conversion
 
@@ -34,10 +41,12 @@ class myTM1637 : TM1637 {
 
     //7+1  Segment patterns for ASCII 0x30-0x5F
     const uint8_t asciiTo8Segment[] = { 
+      0x00,0x86,0x22,0x7f, 0x6d,0x52,0x7d,0x02, //  !"# $%&'
+      0x39,0x0f,0x7f,0x46, 0x80,0x40,0x80,0x52, // ()*+ ,-./
       0x3f,0x06,0x5b,0x4f, 0x66,0x6d,0x7d,0x07, // 0123 4567 
       0x7f,0x6f,0x09,0x89, 0x58,0x48,0x4c,0xD3, // 89:; <=>?
       0x77,0x5f,0x7c,0x39, 0x5E,0x79,0x71,0x3d, // @aBC DEFG NB: @ <-> A in this derived class
-      0x76,0x06,0x0E,0x75, 0x38,0x37,0x54,0x5c, // HIJK LMNO
+      0x74,0x06,0x0E,0x75, 0x38,0x37,0x54,0x5c, // HIJK LMNO
       0x73,0x67,0x50,0x6D, 0x78,0x3E,0x1C,0x9c, // PQRS TUVW
       0x76,0x6E,0x5B,0x39, 0x52,0x0F,0x23,0x08  // XYZ[ /]^_
     };
@@ -45,11 +54,8 @@ class myTM1637 : TM1637 {
     uint8_t  segments = c &0x80;
     c &= 0x7f;
     if ( c >= 0x60 ) c -= 0x20 ; // a-z -> A-Z
-    if ( c == '.' ) segments = 0x80; // decimal point only
-    if ( c == '-' ) segments |= 0x40; // minus sign
-    if ( ( c >= 0x30 ) && ( c <= 0x5F ) ) {
-      int index = c - 0x30;
-      segments |= asciiTo8Segment[index];
+    if ( ( c >= 0x20 ) && ( c <= 0x5F ) ) {
+      segments |= asciiTo8Segment[c-0x20];
     }
     return segments;
   }
@@ -57,15 +63,15 @@ class myTM1637 : TM1637 {
 
 myTM1637 myTM;
 
-const int ADC_PIN = PA0;
-
 void setup()
 {
   Serial.begin(115200);
   delay(1000);
   Serial.println(__FILE__);
 
-  myTM.begin(PB8, PB9 , DISPLAY_DIGITS_6 );       //  clockpin, datapin, digits
+  // set clockpin, datapin to your own board pin names
+  // e.g.  myTM.begin(PB8, PB9 , DISPLAY_DIGITS_6 );
+  myTM.begin( 14, 15 , DISPLAY_DIGITS_6 ); // clockpin, datapin, and digits
 
   myTM.setBrightness(2);
   
@@ -75,10 +81,11 @@ void setup()
 void loop()
 {
   char buff[20];
+  static int seconds;
   // Show A and @ swapped over on custom character set
-  sprintf(buff,"@-A%3d", millis()/1000 );
-  myTM.displayPChar(buff);
-  Serial.println(buff); // Display and serial monitors disagree on A-@ symbols
+  // Compare the 7 segment display with the text shown on the serial monitor
+  sprintf(buff,"@-A%3d", seconds++%100 );
+  myTM.displayPChar(buff); // send buffer to display and serial port
   delay(1000);
 }
 

--- a/examples/TM1637_custom/TM1637_custom.ino
+++ b/examples/TM1637_custom/TM1637_custom.ino
@@ -1,0 +1,86 @@
+//
+//    FILE: TM1637_custom.ino
+//  AUTHOR: Richard Jones
+// VERSION: 0.1.0
+// PURPOSE: demo TM1637 library
+//    DATE: 3 October 2022
+//     URL: https://github.com/radionerd
+
+// Demonstration of how to display char *buff and override the TM1637 library asciiTo7Segment virtual function
+// to create a custom 7 segment character set. 
+// The letter 'A' becomes swapped with @ in this trivial example
+
+
+
+#include "TM1637.h"
+
+const int DISPLAY_DIGITS_6 = 6;
+ 
+class myTM1637 : TM1637 {
+  public:
+  void setBrightness(uint8_t b) { TM1637::setBrightness(b);};
+  
+  void begin(uint8_t clockPin, uint8_t dataPin, uint8_t digits = 6) {TM1637::begin(clockPin,dataPin,digits);};
+  
+  void displayPChar( char * data ) { TM1637::displayPChar( &data[0] );};
+  
+  uint8_t asciiTo7Segment ( char c ) { // Override library ascii to 7 segment conversion
+
+    //        -01-
+    //    20 |    | 02
+    //        -40-
+    //    10 |    | 04
+    //        -08-    .80
+
+    //7+1  Segment patterns for ASCII 0x30-0x5F
+    const uint8_t asciiTo8Segment[] = { 
+      0x3f,0x06,0x5b,0x4f, 0x66,0x6d,0x7d,0x07, // 0123 4567 
+      0x7f,0x6f,0x09,0x89, 0x58,0x48,0x4c,0xD3, // 89:; <=>?
+      0x77,0x5f,0x7c,0x39, 0x5E,0x79,0x71,0x3d, // @aBC DEFG NB: @ <-> A in this derived class
+      0x76,0x06,0x0E,0x75, 0x38,0x37,0x54,0x5c, // HIJK LMNO
+      0x73,0x67,0x50,0x6D, 0x78,0x3E,0x1C,0x9c, // PQRS TUVW
+      0x76,0x6E,0x5B,0x39, 0x52,0x0F,0x23,0x08  // XYZ[ /]^_
+    };
+
+    uint8_t  segments = c &0x80;
+    c &= 0x7f;
+    if ( c >= 0x60 ) c -= 0x20 ; // a-z -> A-Z
+    if ( c == '.' ) segments = 0x80; // decimal point only
+    if ( c == '-' ) segments |= 0x40; // minus sign
+    if ( ( c >= 0x30 ) && ( c <= 0x5F ) ) {
+      int index = c - 0x30;
+      segments |= asciiTo8Segment[index];
+    }
+    return segments;
+  }
+};
+
+myTM1637 myTM;
+
+const int ADC_PIN = PA0;
+
+void setup()
+{
+  Serial.begin(115200);
+  delay(1000);
+  Serial.println(__FILE__);
+
+  myTM.begin(PB8, PB9 , DISPLAY_DIGITS_6 );       //  clockpin, datapin, digits
+
+  myTM.setBrightness(2);
+  
+}
+
+
+void loop()
+{
+  char buff[20];
+  // Show A and @ swapped over on custom character set
+  sprintf(buff,"@-A%3d", millis()/1000 );
+  myTM.displayPChar(buff);
+  Serial.println(buff); // Display and serial monitors disagree on A-@ symbols
+  delay(1000);
+}
+
+
+// -- END OF FILE --

--- a/examples/TM1637_pchar/TM1637_pchar.ino
+++ b/examples/TM1637_pchar/TM1637_pchar.ino
@@ -1,0 +1,44 @@
+//
+//    FILE: TM1637_pchar.ino
+//  AUTHOR: Richard Jones
+// VERSION: 0.1.0
+// PURPOSE: demo TM1637 library
+//    DATE: 4 October 2022
+//     URL: https://github.com/radionerd
+
+// Demonstration of how to display char *buff
+// Status: Experimental. Tested on STM32F103C8T6 Blue Pill and Arduino Nano only
+
+#include "TM1637.h"
+
+const int DISPLAY_DIGITS_6 = 6;
+
+TM1637 TM;
+
+void setup()
+{
+  Serial.begin(115200);
+  delay(1000);
+  Serial.println(__FILE__);
+
+  // set clockpin, datapin to your own board pin names
+  // e.g.  myTM.begin(PB8, PB9 , DISPLAY_DIGITS_6 );
+  TM.begin( 14, 15 , DISPLAY_DIGITS_6 ); // clockpin, datapin, and digits
+
+  TM.setBrightness(2);
+  
+}
+
+
+void loop()
+{
+  char buff[20];
+  static int seconds;
+  sprintf(buff,"Sec=%02x", seconds++&0xFF );
+  TM.displayPChar(buff); // send buffer to display
+  Serial.println(buff);  //  and serial port.
+  delay(1000);
+}
+
+
+// -- END OF FILE --


### PR DESCRIPTION
Hi Rob,
In my branch to your library I have added a displayPChar(char* buff) feature, and an example of how to override the character font using a derived class. Maybe you would like to consider my pull request? I have tested the feature on an STM32F103C8T6 Blue Pill hosting 6 digit display.
Thanks

Richard